### PR TITLE
fix: Change sentry and spotlight integration order

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -28,7 +28,7 @@ export default defineConfig({
   //     noExternal: [/.*sentry.*/],
   //   },
   // },
-  integrations: [spotlightIntegration(), sentryIntegration(), react()],
+  integrations: [sentryIntegration(), spotlightIntegration(), react()],
   // output: "server",
   // adapter: node({
   //   mode: "standalone",


### PR DESCRIPTION
I think it sentry needs to be initialized before spotlight, right? Otherwise we can't access the `__SENTRY__` global when intializing spotlight