### PR TITLE
feat: Allow SDK configuration via dedicated files

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -28,7 +28,14 @@ export default defineConfig({
   //     noExternal: [/.*sentry.*/],
   //   },
   // },
-  integrations: [sentryIntegration(), spotlightIntegration(), react()],
+  integrations: [
+    sentryIntegration({
+      // clientInitPath: "./sentry.client.config.ts",
+      // serverInitPath: "./sentry.server.config.ts",
+    }),
+    spotlightIntegration(),
+    react(),
+  ],
   // output: "server",
   // adapter: node({
   //   mode: "standalone",


### PR DESCRIPTION
For a proper Astro SDK, we need to let users set all (/most) SDK init options of `@sentry/browser` or `@sentry/node`.

The current approach of specifying a few options directly in the `sentryIntegration` (Astro integration) works well for primitive values but for functions like `beforeSend` or integrations, we can't serialize them to string in the same way as we can serialize primitives. 

This PR adds support for SDK setup via dedicated files that contain a `Sentry.init` call (+ the SDK import) for server and client respectively. Users can put them wherever they want (I'd suggest the root dir by default) and during build time, they'll be picked up if the `(server|client)InitPath` options are specified. This is inspired by how our SDK setup works in NextJS and Gatsby. 
 
If a path is not specified, we fall back to our default init injection.

```js
// astro.config.mjs

export default defineConfig({
  integrations: [
    sentryIntegration({
      clientInitPath: "./sentry.client.config.ts",
      serverInitPath: "./sentry.server.config.ts",
    }),
  ],
}),
```